### PR TITLE
Endringer mtp nordiske tegn i politisk behandling schemas

### DIFF
--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/HentMoteplanN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/HentMoteplanN1/testInformation.json
@@ -1,9 +1,9 @@
 ﻿{
-    "testName": "Hent Møteplan, inkluder møter",
-    "description": "Send hent møteplan med inkluderMøter true",
-    "testStep": "Normalsituasjon 1 Input Hent Møteplan, retur Møteplan",
-    "messageType": "no.ks.fiks.politisk.behandling.klient.hentmoteplan.v1",
-    "operation": "HentMoteplan",
+    "testName": "Hent Møteplan",
+    "description": "Send hent møteplan",
+    "testStep": "Normalsituasjon 1 Input HentMoeteplan, retur Moeteplan",
+    "messageType": "no.ks.fiks.politisk.behandling.klient.hentmoeteplan.v1",
+    "operation": "HentMoeteplan",
     "situation": "N1",
     "expectedResult": "Møteplan med utfylte standardverdier",
     "queriesWithExpectedValues": [
@@ -19,7 +19,7 @@
         },
         {
             "payloadQuery": "$",
-            "expectedValue": "møte",
+            "expectedValue": "moete",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
@@ -33,7 +33,7 @@
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "$.møte[*]",
+            "payloadQuery": "$.moete[*]",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/SendDelegertVedtakN1/sampleDelegertVedtak.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/SendDelegertVedtakN1/sampleDelegertVedtak.json
@@ -33,19 +33,19 @@
                 "referanseDokumentfil"
             ]
         },
-        "Møte": {
+        "Moete": {
             "type": "object",
             "properties": {
-                "møteid": {
+                "moeteid": {
                     "type": "string"
                 },
-                "møtedato": {
+                "moetedato": {
                     "type": "string",
                     "format": "date-time"
                 }
             },
             "required": [
-                "møteid"
+                "moeteid"
             ]
         }
     },
@@ -60,25 +60,25 @@
         "sak": {
             "type": "object",
             "properties": {
-                "referanseEksternNøkkel": {
+                "referanseEksternNoekkel": {
                     "type": "object",
                     "properties": {
                         "fagsystem": {
                             "type": "string"
                         },
-                        "nøkkel": {
+                        "noekkel": {
                             "type": "string"
                         }
                     },
                     "required": [
                         "fagsystem",
-                        "nøkkel"
+                        "noekkel"
                     ]
                 },
                 "fagsystemetsSaksnummer": {
                     "type": "object",
                     "properties": {
-                        "saksår": {
+                        "saksaar": {
                             "type": "integer"
                         },
                         "sakssekvensnummer": {
@@ -86,14 +86,14 @@
                         }
                     },
                     "required": [
-                        "saksår",
+                        "saksaar",
                         "sakssekvensnummer"
                     ]
                 },
                 "utvalgetsSaksnummer": {
                     "type": "object",
                     "properties": {
-                        "saksår": {
+                        "saksaar": {
                             "type": "integer"
                         },
                         "sakssekvensnummer": {
@@ -101,7 +101,7 @@
                         }
                     },
                     "required": [
-                        "saksår",
+                        "saksaar",
                         "sakssekvensnummer"
                     ]
                 },
@@ -205,7 +205,7 @@
                 }
             },
             "required": [
-                "referanseEksternNøkkel",
+                "referanseEksternNoekkel",
                 "fagsystemetsSaksnummer",
                 "tittel",
                 "vedtaksdato",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/SendOrienteringssakN1/sampleSendOrienteringssak.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/SendOrienteringssakN1/sampleSendOrienteringssak.json
@@ -6,12 +6,12 @@
         }
     ],
     "sak": {
-        "referanseEksternNøkkel": {
+        "referanseEksternNoekkel": {
             "fagsystem": "ePlansak",
-            "nøkkel": "AB123456789"
+            "noekkel": "AB123456789"
         },
         "fagsystemetsSaksnummer": {
-            "saksår": 2021,
+            "saksaar": 2021,
             "sakssekvensnummer": 11
         },
         "tittel": "Orientering om ny forskrift ....",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/SendUtvalgsakN1/sampleSendUtvalgsak.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.politisk.behandling.klient.v1/SendUtvalgsakN1/sampleSendUtvalgsak.json
@@ -6,12 +6,12 @@
         }
     ],
     "sak": {
-        "referanseEksternNøkkel": {
+        "referanseEksternNoekkel": {
             "fagsystem": "ePlansak",
-            "nøkkel": "AB123456789"
+            "noekkel": "AB123456789"
         },
         "fagsystemetsSaksnummer": {
-            "saksår": 2021,
+            "saksaar": 2021,
             "sakssekvensnummer": 2
         },
         "tittel": "OMRÅDEREGULERING FOR HIS Allè - BEHANDLING FØR HØRING OG UTLEGGING TIL OFFENTLIG ETTERSYN",


### PR DESCRIPTION
Nye schemas for politisk behandling har blitt endret slik at de ikke lenger har ø,æ og å. 
Fikset i testcases.