### PR TITLE
Mulig å velge Fiks-konto som query parameter fikskonto i url-adressen

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Man kan kjøre det på flere måter:
 [Fiks-Protokollvalidator i development er her](https://forvaltning.fiks.dev.ks.no/fiks-validator/#/) 
 
 Konto id man kan benytte:
-- Arkivsystem: 760fd7d6-435f-4c1b-97d5-92fbe2f603b0
-- Fagsystem arkiv: 4a416cde-2aca-4eef-bec4-efddcee0fcea
-- Politisk behandling: 33f6baa8-6645-4dca-9ffb-f95f43333f6c
+- Arkivsystem: [760fd7d6-435f-4c1b-97d5-92fbe2f603b0](https://forvaltning.fiks.dev.ks.no/fiks-validator/#/NewTestSession?fikskonto=760fd7d6-435f-4c1b-97d5-92fbe2f603b0)
+- Fagsystem arkiv: [4a416cde-2aca-4eef-bec4-efddcee0fcea](https://forvaltning.fiks.dev.ks.no/fiks-validator/#/NewTestSession?fikskonto=4a416cde-2aca-4eef-bec4-efddcee0fcea)
+- Politisk behandling: [33f6baa8-6645-4dca-9ffb-f95f43333f6c](https://forvaltning.fiks.dev.ks.no/fiks-validator/#/NewTestSession?fikskonto=33f6baa8-6645-4dca-9ffb-f95f43333f6c)
 
 ## Testing i Test miljø
 [Fiks-Protokollvalidator i test er her](https://forvaltning.fiks.test.ks.no/fiks-validator/#/)
 
 Konto id man kan benytte:
-- Arkivsystem: 8752e128-0e2b-494c-8fab-8e3577aca13d
-- Fagsystem arkiv: 91307c59-0ddb-4212-bede-59f98e0edf77
-- Politisk behandling: f95f6811-99db-4169-b7df-7090cffa4174
+- Arkivsystem: [8752e128-0e2b-494c-8fab-8e3577aca13d](https://forvaltning.fiks.test.ks.no/fiks-validator/#/NewTestSession?fikskonto=8752e128-0e2b-494c-8fab-8e3577aca13d)
+- Fagsystem arkiv: [91307c59-0ddb-4212-bede-59f98e0edf77](https://forvaltning.fiks.test.ks.no/fiks-validator/#/NewTestSession?fikskonto=91307c59-0ddb-4212-bede-59f98e0edf77)
+- Politisk behandling: [f95f6811-99db-4169-b7df-7090cffa4174](https://forvaltning.fiks.test.ks.no/fiks-validator/#/NewTestSession?fikskonto=f95f6811-99db-4169-b7df-7090cffa4174)
 
 ## Oppsett og kjøring lokalt vha docker-compose
 

--- a/web-ui/src/components/NewTestSession.vue
+++ b/web-ui/src/components/NewTestSession.vue
@@ -147,6 +147,9 @@ export default {
   
   mounted() {
     this.recipientId = this.$route.query.fikskonto;
+    if(this.$route.query.fikskonto !== null) {
+      this.fiksAccountPresent = true;
+    }
   },
   
   computed: {

--- a/web-ui/src/components/NewTestSession.vue
+++ b/web-ui/src/components/NewTestSession.vue
@@ -126,7 +126,7 @@ export default {
       hasRun: false,
       loading: false,
       hasLoaded: false,
-      recipientId: null,
+      recipientId: this.$route.query.fikskonto,
       selectedTests: [],
       fiksAccountPresent: false,
       allTestsSelected: false,
@@ -143,6 +143,10 @@ export default {
           { value: 'no.ks.fiks.politisk.behandling.tjener.v1', text: 'no.ks.fiks.politisk.behandling.v1 (tjener)'},
         ]
     };
+  },
+  
+  mounted() {
+    this.recipientId = this.$route.query.fikskonto;
   },
   
   computed: {


### PR DESCRIPTION
Nå kan man slippe å kopiere inn riktig konto ved å angi det som en query-param og man kan da f.eks. lagre som bookmark pr konto-id eller man kan lenke til det fra dokumentasjon, README.md osv. 