### PR TITLE
Oppdatert til siste meldinstypene og schemas

### DIFF
--- a/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
+++ b/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="KS.Fiks.IO.Arkiv.Client" Version="2.0.7" />
+    <PackageReference Include="KS.Fiks.IO.Arkiv.Client" Version="2.0.10" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />

--- a/api/KS.FiksProtokollValidator.WebAPI/Data/TestSeeder.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Data/TestSeeder.cs
@@ -133,6 +133,7 @@ namespace KS.FiksProtokollValidator.WebAPI.Data
         {
             if (testInformation["queriesWithExpectedValues"] == null)
             {
+                testCase.FiksResponseTests.Clear();
                 return;
             }
             
@@ -141,36 +142,29 @@ namespace KS.FiksProtokollValidator.WebAPI.Data
                 testCase.FiksResponseTests = new List<FiksResponseTest>();
                 foreach (var queryWithExpectedValue in testInformation["queriesWithExpectedValues"])
                 {
-                    var fiksResponseTest = new FiksResponseTest
-                    {
-                        PayloadQuery = (string) queryWithExpectedValue["payloadQuery"],
-                        ExpectedValue = (string) queryWithExpectedValue["expectedValue"],
-                        ValueType = (SearchValueType) (int) queryWithExpectedValue["valueType"]
-                    };
-
-                    testCase.FiksResponseTests.Add(fiksResponseTest);
+                    AddNewFiksResponseTest(testCase, queryWithExpectedValue);
                 }
             }
             else
-            {
+            {  
+                testCase.FiksResponseTests.Clear();  
                 foreach (var queryWithExpectedValue in testInformation["queriesWithExpectedValues"])
                 {
-                    var fiksResponseTest = new FiksResponseTest
-                    {
-                        PayloadQuery = (string) queryWithExpectedValue["payloadQuery"],
-                        ExpectedValue = (string) queryWithExpectedValue["expectedValue"],
-                        ValueType = (SearchValueType) (int) queryWithExpectedValue["valueType"]
-                    };
-                    if (!testCase.FiksResponseTests.Any(
-                        r => (r.ExpectedValue.Equals(fiksResponseTest.ExpectedValue)
-                              && r.PayloadQuery.Equals(fiksResponseTest.PayloadQuery)
-                              && r.ValueType.Equals(fiksResponseTest.ValueType))
-                    ))
-                    {
-                        testCase.FiksResponseTests.Add(fiksResponseTest);
-                    }
+                    AddNewFiksResponseTest(testCase, queryWithExpectedValue);
                 }
             }
+        }
+
+        private static void AddNewFiksResponseTest(TestCase testCase, JToken queryWithExpectedValue)
+        {
+            var fiksResponseTest = new FiksResponseTest
+            {
+                PayloadQuery = (string)queryWithExpectedValue["payloadQuery"],
+                ExpectedValue = (string)queryWithExpectedValue["expectedValue"],
+                ValueType = (SearchValueType)(int)queryWithExpectedValue["valueType"]
+            };
+
+            testCase.FiksResponseTests.Add(fiksResponseTest);
         }
 
         private void DeleteFiksExpectedResponseMessageTypes(TestCase testCase, JObject testInformation)

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-    <PackageReference Include="KS.Fiks.IO.Arkiv.Client" Version="2.0.7" />
+    <PackageReference Include="KS.Fiks.IO.Arkiv.Client" Version="2.0.10" />
     <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.4" />
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.15" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.5" />

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/testInformation.json
@@ -8,27 +8,27 @@
     "expectedResult": "Journalpost med utfylte standardverdier",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "/arkivmeldingKvittering/registrering",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering",
             "expectedValue": "journalpost",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmeldingKvittering/registrering/systemID",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/systemID",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmeldingKvittering/registrering/journalaar",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalaar",
             "expectedValue": "2021",
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmeldingKvittering/registrering/journalsekvensnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalsekvensnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmeldingKvittering/registrering/journalpostnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalpostnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/testInformation.json
@@ -8,27 +8,27 @@
     "expectedResult": "Journalpost med utfylte standardverdier",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "/arkivmelding/registrering",
+            "payloadQuery": "/arkivmeldingKvittering/registrering",
             "expectedValue": "journalpost",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/systemID",
+            "payloadQuery": "/arkivmeldingKvittering/registrering/systemID",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalaar",
+            "payloadQuery": "/arkivmeldingKvittering/registrering/journalaar",
             "expectedValue": "2021",
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalsekvensnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registrering/journalsekvensnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalpostnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registrering/journalpostnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/testInformation.json
@@ -9,7 +9,7 @@
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "/arkivmeldingKvittering/registreringKvittering",
-            "expectedValue": "journalpost",
+            "expectedValue": "journalpostKvittering",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN6/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN6/testInformation.json
@@ -8,27 +8,27 @@
     "expectedResult": "Journalpost og avsender/mottak er med utfylte standardverdier",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "/arkivmelding/registrering",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering",
             "expectedValue": "journalpost",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/systemID",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/systemID",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalaar",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalaar",
             "expectedValue": "2021",
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalsekvensnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalsekvensnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalpostnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalpostnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN6/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN6/testInformation.json
@@ -9,7 +9,7 @@
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "/arkivmeldingKvittering/registreringKvittering",
-            "expectedValue": "journalpost",
+            "expectedValue": "journalpostKvittering",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN8/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN8/testInformation.json
@@ -9,7 +9,7 @@
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "/arkivmeldingKvittering/registreringKvittering",
-            "expectedValue": "journalpost",
+            "expectedValue": "journalpostKvittering",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN8/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN8/testInformation.json
@@ -8,27 +8,27 @@
     "expectedResult": "Journalpost og avskrivning med utfylte standardverdier",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "/arkivmelding/registrering",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering",
             "expectedValue": "journalpost",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/systemID",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/systemID",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalaar",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalaar",
             "expectedValue": "2021",
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalsekvensnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalsekvensnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/registrering/journalpostnummer",
+            "payloadQuery": "/arkivmeldingKvittering/registreringKvittering/journalpostnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeN1/testInformation.json
@@ -9,7 +9,7 @@
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "/arkivmeldingKvittering/mappeKvittering",
-            "expectedValue": "saksmappe",
+            "expectedValue": "saksmappeKvittering",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeN1/testInformation.json
@@ -8,22 +8,22 @@
     "expectedResult": "Saksmappe med utfylte standardverdier",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "/arkivmelding/mappe",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering",
             "expectedValue": "saksmappe",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/mappe/saksaar",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering/saksaar",
             "expectedValue": "2021",
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/mappe/systemID",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering/systemID",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/mappe/sakssekvensnummer",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering/sakssekvensnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeN6/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeN6/testInformation.json
@@ -8,22 +8,22 @@
     "expectedResult": "Saksmappe og klasse med utfylte standardverdier",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "/arkivmelding/mappe",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering",
             "expectedValue": "saksmappe",
             "valueType": 1 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/mappe/saksaar",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering/saksaar",
             "expectedValue": "2021",
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/mappe/systemID",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering/systemID",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "/arkivmelding/mappe/sakssekvensnummer",
+            "payloadQuery": "/arkivmeldingKvittering/mappeKvittering/sakssekvensnummer",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }


### PR DESCRIPTION
Har oppdatert testene mtp hva de sjekker av xpath mot melding som kommer inn.
Applikasjonen vil nå også truncate tabellen FiksResponseTest som inneholder hva testene sjekker av data som kommer inn. Denne tabellen kan like godt bygges opp på nytt hver gang man starter opp applikasjonen på nytt da det ble vondt å sjekke om testene faktisk har forandret seg, er tatt bort eller er ny. Det er ikke noen id på selve testene som stemmer 1-1 mot innholdet i json-filen.