### PR TITLE
Viser forventet filnavn i melding fra validator

### DIFF
--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/FiksResponseValidator.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/FiksResponseValidator.cs
@@ -141,7 +141,7 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
             if (!HasCorrectFilename(fiksResponse.Type, receivedPayloadFileName))
             {
                 validationErrors.Add(string.Format(
-                    ValidationErrorMessages.InvalidPayloadFilename, receivedPayloadFileName
+                    ValidationErrorMessages.InvalidPayloadFilename, receivedPayloadFileName, GetExpectedFileName(messageType)
                 ));
                 return;
             }
@@ -183,7 +183,6 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
         {
             return GetExpectedFileName(messageType).Equals(filename);
         }
-        
         
         private static string GetExpectedFileName(string messageType)
         {
@@ -350,10 +349,10 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
                                     keyIsPresent = JObject.Parse(token.ToString()).ContainsKey(expectedValue);
                                 }
 
-                                    if (keyIsPresent)
-                                    {
-                                        foundExpectedValue = true;
-                                    }
+                                if (keyIsPresent)
+                                {
+                                    foundExpectedValue = true;
+                                }
                                   
                             }
                             if (!foundExpectedValue)

--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/Resources/ValidationErrorMessages.resx
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/Resources/ValidationErrorMessages.resx
@@ -121,7 +121,7 @@
     <value>Ugyldig filformat på payload: {0}</value>
   </data>
   <data name="InvalidPayloadFilename" xml:space="preserve">
-    <value>Ugyldig filnavn på payload: {0}</value>
+    <value>Ugyldig filnavn på payload: {0}. Forventet filnavn: {1}</value>
   </data>
   <data name="MissingAttributeOnPayloadElement" xml:space="preserve">
     <value>Fant ikke attributt {0} på node {1}</value>


### PR DESCRIPTION
Det viste bare at man hadde feil filnavn i teksten. Nå viser også forventet filnavn.