### PR TITLE
Endret til å bruke azure-sql-edge image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   fiks-protokoll-validator-sqlexpress:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/azure-sql-edge:latest
     environment:
       SA_PASSWORD: "Dev#FiksProtokollValidator1234"
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
Bruker nytt image for databasen da den gamle ikke funker på Apple silicon

Det viser seg at den gamle, `mssql/server:2019` ikke funker på de nye Apple prosessorene (arm). 
Men `azure-sql-edge` funker og ser ut til funke fint til vårt bruke