### PR TITLE
.net6 og nye feilmeldinger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ def buildAndPushDockerImageApi(boolean isRelease = false) {
       def customImage
     
       println("Building API code in Docker image")
-      docker.image('mcr.microsoft.com/dotnet/sdk:5.0-alpine').inside() {
+      docker.image('mcr.microsoft.com/dotnet/sdk:6.0-alpine').inside() {
         sh '''
             dotnet publish --configuration Release KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj --output published-api
         '''

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 ARG build_version_number=undefined
 WORKDIR /app
 

--- a/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
+++ b/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.8" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />

--- a/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
+++ b/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -55,7 +55,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.8" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
     <PackageReference Include="Moq" Version="4.18.0" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
     <StartupObject>KS.FiksProtokollValidator.WebAPI.Program</StartupObject>
     <VersionPrefix>1.0.33</VersionPrefix>
@@ -33,9 +33,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.8" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.9" />
+    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.17" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
     <PackageReference Include="KS.Fiks.Protokoller.V1" Version="1.0.0" />

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF1/testInformation.json
@@ -5,7 +5,7 @@
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.journalpost.hent",
     "operation": "HentJournalpost",
     "situation": "F1",
-    "expectedResult": "Melding med messagetype no.ks.fiks.kvittering.ikkefunnet.v1",
+    "expectedResult": "Melding med messagetype no.ks.fiks.arkiv.v1.feilmelding.ikkefunnet",
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "$",
@@ -33,7 +33,7 @@
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }
     ],
-    "expectedResponseMessageTypes": [ "no.ks.fiks.kvittering.ikkefunnet.v1" ],
+    "expectedResponseMessageTypes": [ "no.ks.fiks.arkiv.v1.feilmelding.ikkefunnet" ],
     "supported": true,
     "protocol": "no.ks.fiks.arkiv.v1"
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF2/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF2/testInformation.json
@@ -5,7 +5,7 @@
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.journalpost.hent",
     "operation": "HentJournalpost",
     "situation": "F2",
-    "expectedResult": "Melding med messagetype no.ks.fiks.kvittering.ugyldigforespoersel.v1",
+    "expectedResult": "Melding med messagetype no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel",
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "$",
@@ -33,7 +33,7 @@
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }
     ],
-    "expectedResponseMessageTypes": [ "no.ks.fiks.kvittering.ugyldigforespoersel.v1" ],
+    "expectedResponseMessageTypes": [ "no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel" ],
     "supported": true,
     "protocol": "no.ks.fiks.arkiv.v1"
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeFX/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeFX/testInformation.json
@@ -5,7 +5,7 @@
     "messageType": "no.ks.fiks.arkiv.v1.arkivering.arkivmelding",
     "operation": "NySaksmappe",
     "situation": "FX",
-    "expectedResult": "Melding med messagetype no.ks.fiks.kvittering.ugyldigforespoersel.v1",
+    "expectedResult": "Melding med messagetype no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel",
     "queriesWithExpectedValues": [
         {
             "payloadQuery": "$",
@@ -33,7 +33,7 @@
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }
     ],
-    "expectedResponseMessageTypes": [ "no.ks.fiks.kvittering.ugyldigforespoersel.v1" ],
+    "expectedResponseMessageTypes": [ "no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel" ],
     "supported": true, 
     "protocol": "no.ks.fiks.arkiv.v1"
 }


### PR DESCRIPTION
Oppgradert til .net 6 og oppdatert testene til de nye feilmelding meldingstypene

Vi kjører nå på .net 6 og har oppdatert testcasene som sjekket mot forventede feilmeldinger.
F.eks. er det endret fra `no.ks.fiks.kvittering.ugyldigforespoersel.v1`til `no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel`.
Jenkinsfile er endret også mtp å bygge med .net6 image