### PR TITLE
Oppdatert i henhold til siste fiks-arkiv protkoll endringer

### DIFF
--- a/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
+++ b/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />

--- a/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
+++ b/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
@@ -55,8 +55,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
     <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.12" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.12" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
     <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.17" />

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF1/testInformation.json
@@ -8,27 +8,12 @@
     "expectedResult": "Melding med messagetype no.ks.fiks.arkiv.v1.feilmelding.ikkefunnet",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "$",
-            "expectedValue": "errorId",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$",
-            "expectedValue": "feilmelding",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$",
-            "expectedValue": "correlationId",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$.errorId",
+            "payloadQuery": "/ikkefunnet/feilId",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "$.correlationId",
+            "payloadQuery": "/ikkefunnet/feilmelding",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF2/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostF2/testInformation.json
@@ -8,27 +8,12 @@
     "expectedResult": "Melding med messagetype no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "$",
-            "expectedValue": "errorId",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$",
-            "expectedValue": "feilmelding",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$",
-            "expectedValue": "correlationId",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$.errorId",
+            "payloadQuery": "/ugyldigforespoersel/feilId",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "$.correlationId",
+            "payloadQuery": "/ugyldigforespoersel/feilmelding",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/arkivmelding.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN1/arkivmelding.xml
@@ -8,7 +8,9 @@
 	<registrering xsi:type="journalpost">
 		<opprettetAv>Fagsystemets brukerid</opprettetAv>
 		<arkivertAv>Fagsystemets brukerid</arkivertAv>
-		<referanseForelderMappe>22f05e04-37c4-4051-8b3a-853c8eac4b33</referanseForelderMappe>
+		<referanseForelderMappe>
+			<systemID>22f05e04-37c4-4051-8b3a-853c8eac4b33</systemID>
+		</referanseForelderMappe>
 		<dokumentbeskrivelse>
 			<dokumenttype>
 				<kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN6/arkivmelding.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN6/arkivmelding.xml
@@ -7,7 +7,9 @@
 	<registrering xsi:type="journalpost">
 		<opprettetAv>Fagsystemets brukerid</opprettetAv>
 		<arkivertAv>Fagsystemets brukerid</arkivertAv>
-		<referanseForelderMappe>22f05e04-37c4-4051-8b3a-853c8eac4b33</referanseForelderMappe>
+		<referanseForelderMappe>
+			<systemID>22f05e04-37c4-4051-8b3a-853c8eac4b33</systemID>
+		</referanseForelderMappe>
 		<dokumentbeskrivelse>
 			<dokumenttype>
 				<kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN8/arkivmelding.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NyJournalpostN8/arkivmelding.xml
@@ -7,7 +7,9 @@
 	<registrering xsi:type="journalpost">
 		<opprettetAv>Fagsystemets brukerid</opprettetAv>
 		<arkivertAv>Fagsystemets brukerid</arkivertAv>
-		<referanseForelderMappe>22f05e04-37c4-4051-8b3a-853c8eac4b33</referanseForelderMappe>
+		<referanseForelderMappe>
+			<systemID>22f05e04-37c4-4051-8b3a-853c8eac4b33</systemID>
+		</referanseForelderMappe>
 		<dokumentbeskrivelse>
 			<dokumenttype>
 				<kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeFX/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySaksmappeFX/testInformation.json
@@ -8,27 +8,12 @@
     "expectedResult": "Melding med messagetype no.ks.fiks.arkiv.v1.feilmelding.ugyldigforespoersel",
     "queriesWithExpectedValues": [
         {
-            "payloadQuery": "$",
-            "expectedValue": "errorId",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$",
-            "expectedValue": "feilmelding",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$",
-            "expectedValue": "correlationId",
-            "valueType": 1 // 0 = Verdi, 1 = Attributt
-        },
-        {
-            "payloadQuery": "$.errorId",
+            "payloadQuery": "/ugyldigforespoersel/feilId",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         },
         {
-            "payloadQuery": "$.correlationId",
+            "payloadQuery": "/ugyldigforespoersel/feilmelding",
             "expectedValue": "*", // * = en hvilken som helst verdi som ikke er tom, null eller whitespace
             "valueType": 0 // 0 = Verdi, 1 = Attributt
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/PayloadChecksHelper.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/PayloadChecksHelper.cs
@@ -14,7 +14,7 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
     public static class PayloadChecksHelper
     {
         public static HashSet<string> GetMessageTypesWithPayload()
-        { //NB Husk at man må fylle på i denne listen med de meldingstyper som har resultat.
+        {
             return new HashSet<string>
             {
                 FiksArkivMeldingtype.ArkivmeldingKvittering,
@@ -24,12 +24,12 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
                 FiksArkivMeldingtype.JournalpostHentResultat,
                 FiksArkivMeldingtype.MappeHentResultat,
                 FiksArkivMeldingtype.DokumentfilHentResultat,
+                FiksArkivMeldingtype.Ugyldigforespørsel,
+                FiksArkivMeldingtype.Ikkefunnet,
+                FiksArkivMeldingtype.Serverfeil,
                 ResponseMessageTypes.FeilV1, //TODO er denne i bruk?
                 PolitiskBehandlingMeldingTypeV1.ResultatMoeteplan,
                 PolitiskBehandlingMeldingTypeV1.ResultatUtvalg,
-                FeilmeldingType.Ugyldigforespørsel,
-                FeilmeldingType.Ikkefunnet,
-                FeilmeldingType.Serverfeil,
                 FiksPlanMeldingtypeV2.ResultatFinnPlanerForMatrikkelenhet,
                 FiksPlanMeldingtypeV2.ResultatFinnPlaner,
                 FiksPlanMeldingtypeV2.ResultatFinnDispensasjoner,
@@ -47,6 +47,7 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
                 FiksPlanMeldingtypeV2.ResultatFinnPlanerForOmraade,
                 FiksPlanMeldingtypeV2.ResultatSjekkMidlertidigForbud,
             };
+            //NB Husk at man må fylle på i denne listen med de meldingstyper som har resultat.
         }
 
         public static string GetExpectedFileName(string messageType)
@@ -69,6 +70,10 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
                 case FiksArkivMeldingtype.DokumentfilHentResultat:
                 case FiksArkivMeldingtype.MappeHentResultat:
                     return "resultat.xml";
+                case FiksArkivMeldingtype.Ugyldigforespørsel:
+                case FiksArkivMeldingtype.Serverfeil:
+                case FiksArkivMeldingtype.Ikkefunnet:
+                    return "feilmelding.xml";
                 case PolitiskBehandlingMeldingTypeV1.HentMoeteplan:
                 case PolitiskBehandlingMeldingTypeV1.HentUtvalg:
                 case PolitiskBehandlingMeldingTypeV1.SendOrienteringssak:
@@ -80,9 +85,6 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
                 case PolitiskBehandlingMeldingTypeV1.SendVedtakTilEInnsyn:
                 case PolitiskBehandlingMeldingTypeV1.ResultatMoeteplan:
                 case PolitiskBehandlingMeldingTypeV1.ResultatUtvalg:
-                case FeilmeldingType.Ugyldigforespørsel:
-                case FeilmeldingType.Serverfeil:
-                case FeilmeldingType.Ikkefunnet:
                 case FiksPlanMeldingtypeV2.ResultatFinnDispensasjoner:
                 case FiksPlanMeldingtypeV2.ResultatFinnPlanbehandlinger:
                 case FiksPlanMeldingtypeV2.ResultatFinnPlandokumenter:


### PR DESCRIPTION
Oppdatert slik at tester funker igjen etter siste fiks-arkiv protokoll endringer

Tester som sjekket feilmeldinger måtte oppdateres etter at de nå ligger under fiks-arkiv protokollen. 
Det måtte gjøres endringer også i tester pga den nye ReferanseForelderMappe typen.