### PR TITLE
Korrigert sok.xml i testcasene etter 0.9.3 endringer i Fiks-Arkiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ OBS: For Windows og OSX vil man få begge deler installert hvis man bruker Docke
 #### Database
 **Dette må kun gjøres første gang**:
 
-Start sqlexpress i docker ved å kjøre `docker-compose up protokoll-validator-sqlexpress`.
+Start sqlexpress i docker ved å kjøre `docker-compose up fiks-protokoll-validator-sqlexpress`.
 Sørg for at din config (appsettings.Development.json) peker til riktig database.
 
 **Oppdater databasen:**

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN1/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN1/sok.xml
@@ -5,15 +5,16 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>mappe</respons>
-	<parameter>
-		<felt>mappeTittel</felt>
-		<operator>equal</operator>
-		<parameterverdier>
-			<stringvalues>
-				<value>Test*</value>
-			</stringvalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>minimum</responsType>
+	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
+		<responstype>minimum</responstype>
+		<parametere>
+			<operator>equal</operator>
+			<sokVerdier>
+				<stringvalues>
+					<value>Test*</value>
+				</stringvalues>
+			</sokVerdier>
+			<felt>mappeTittel</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN2/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN2/sok.xml
@@ -5,15 +5,16 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>mappe</respons>
-	<parameter>
-		<felt>mappeTittel</felt>
-		<operator>equal</operator>
-		<parameterverdier>
-			<stringvalues>
-				<value>Test*</value>
-			</stringvalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>utvidet</responsType>
+	<sokdefinisjon xsi:type="mappeSokdefinisjon">
+		<responstype>utvidet</responstype>
+		<parametere>
+			<operator>equal</operator>
+			<sokVerdier>
+				<stringvalues>
+					<value>Test*</value>
+				</stringvalues>
+			</sokVerdier>
+			<felt>mappeTittel</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN3/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN3/sok.xml
@@ -5,15 +5,16 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>mappe</respons>
-	<parameter>
-		<felt>mappeTittel</felt>
-		<operator>equal</operator>
-		<parameterverdier>
-			<stringvalues>
-				<value>Test*</value>
-			</stringvalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>noekler</responsType>
+	<sokdefinisjon xsi:type="mappeSokdefinisjon">
+		<responstype>noekler</responstype>
+		<parametere>
+			<operator>equal</operator>
+			<sokVerdier>
+				<stringvalues>
+					<value>Test*</value>
+				</stringvalues>
+			</sokVerdier>
+			<felt>mappeTittel</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN4/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN4/sok.xml
@@ -5,16 +5,17 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>saksmappe</respons>
-	<parameter>
-		<felt>sakSaksdato</felt>
-		<operator>between</operator>
-		<parameterverdier>
-			<datevalues>
-				<value>2021-11-01T00:00:00.0</value>
-				<value>2021-12-31T23:59:59.0</value>
-			</datevalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>minimum</responsType>
+	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
+		<responstype>minimum</responstype>
+		<parametere>
+			<operator>between</operator>
+			<sokVerdier>
+				<datevalues>
+					<value>2021-11-01T00:00:00.0</value>
+					<value>2021-12-31T23:59:59.0</value>
+				</datevalues>
+			</sokVerdier>
+			<felt>sakSaksdato</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok> 

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN5/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN5/sok.xml
@@ -5,15 +5,16 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>saksmappe</respons>
-	<parameter>
-		<felt>mappeTittel</felt>
-		<operator>equal</operator>
-		<parameterverdier>
-			<stringvalues>
-				<value>Test*</value>
-			</stringvalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>minimum</responsType>
+	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
+		<responstype>minimum</responstype>
+		<parametere>
+			<operator>equal</operator>
+			<sokVerdier>
+				<stringvalues>
+					<value>Test*</value>
+				</stringvalues>
+			</sokVerdier>
+			<felt>mappeTittel</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN6/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN6/sok.xml
@@ -5,15 +5,16 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>saksmappe</respons>
-	<parameter>
-		<felt>mappeTittel</felt>
-		<operator>equal</operator>
-		<parameterverdier>
-			<stringvalues>
-				<value>Test*</value>
-			</stringvalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>utvidet</responsType>
+	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
+		<responstype>utvidet</responstype>
+		<parametere>
+			<operator>equal</operator>
+			<sokVerdier>
+				<stringvalues>
+					<value>Test*</value>
+				</stringvalues>
+			</sokVerdier>
+			<felt>mappeTittel</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN7/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN7/sok.xml
@@ -5,15 +5,16 @@
 	<tidspunkt>2021-03-23T10:28:33.1952112+01:00</tidspunkt>
 	<take>100</take>
 	<skip>0</skip>
-	<respons>saksmappe</respons>
-	<parameter>
-		<felt>mappeTittel</felt>
-		<operator>equal</operator>
-		<parameterverdier>
-			<stringvalues>
-				<value>Test*</value>
-			</stringvalues>
-		</parameterverdier>
-	</parameter>
-	<responsType>noekler</responsType>
+	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
+		<responstype>noekler</responstype>
+		<parametere>
+			<operator>equal</operator>
+			<sokVerdier>
+				<stringvalues>
+					<value>Test*</value>
+				</stringvalues>
+			</sokVerdier>
+			<felt>mappeTittel</felt>
+		</parametere>
+	</sokdefinisjon>
 </sok>

--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/FiksResponseValidator.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/FiksResponseValidator.cs
@@ -184,10 +184,13 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
             List<string> validationErrors)
         {
             // If Fiks-Arkiv search, check result against the actual search request
-            if (fiksRequest.TestCase.MessageType == FiksArkivMeldingtype.Sok)
+            //TODO either fix this search validation or delete it. Doesnt work at the moment
+            /*
+             if (fiksRequest.TestCase.MessageType == FiksArkivMeldingtype.Sok)
             {
                 SokeresultatValidator.ValidateXmlPayloadWithSokRequest(xmlPayloadContent, fiksRequest, validationErrors);
             }
+            */
             
             // Use of xpath checks in testinformation.json
             var xmlDoc = XDocument.Parse(xmlPayloadContent);

--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/XsdValidator.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/XsdValidator.cs
@@ -45,6 +45,16 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation
                         schemaReader);
                 }
             }
+            
+            using (var schemaStream =
+                   arkivModelsAssembly.GetManifestResourceStream("KS.Fiks.Arkiv.Models.V1.Schema.V1.no.ks.fiks.arkiv.v1.innsyn.sok.xsd"))
+            {
+                using (var schemaReader = XmlReader.Create(schemaStream))
+                {
+                    _xmlSchemaSet.Add("https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sok/v1",
+                        schemaReader);
+                }
+            }
 
             using (var schemaStream =
                 arkivModelsAssembly.GetManifestResourceStream("KS.Fiks.Arkiv.Models.V1.Schema.V1.no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum.xsd"))


### PR DESCRIPTION
Korrigert sok.xml i testcasene etter 0.9.3 endringer i Fiks-Arkiv

Midlertidig disablet den dynamiske "smarte" valideringen av svaret man får tilbake på søk testcasene. Store endringer har gjort at dette må enten skrives på nytt eller forkastes og erstattes med statisk sjekk i testcasene