### PR TITLE
La til healthz og self-healing i BackgroundService

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ def buildAndPushDockerImageApi(boolean isRelease = false) {
       println("Building API code in Docker image")
       docker.image('mcr.microsoft.com/dotnet/sdk:6.0-alpine').inside() {
         sh '''
-            dotnet publish --configuration Release KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj --output published-api
+            dotnet publish -e XDG_DATA_HOME=/tmp --configuration Release KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj --output published-api
         '''
       }
       println("Building API image")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,9 +173,9 @@ def buildAndPushDockerImageApi(boolean isRelease = false) {
       def customImage
     
       println("Building API code in Docker image")
-      docker.image('mcr.microsoft.com/dotnet/sdk:6.0-alpine').inside() {
+      docker.image('mcr.microsoft.com/dotnet/sdk:6.0.401-alpine3.16').inside() {
         sh '''
-            dotnet publish -e XDG_DATA_HOME=/tmp --configuration Release KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj --output published-api
+            dotnet publish --configuration Release KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj --output published-api
         '''
       }
       println("Building API image")

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Det er da ferdige TestCases for meldingene som brukes til dette.
 Dette gjøres først ved at xml eller json meldingene validerer mot tilhørende skjema (xsd, json-schema) for den meldingstypen i protokollen.
 Deretter har hver TestCase definert tester på innholdet i meldingen som blir validert.
 
+## Applikasjon
+
+Applikasjonen kjører front-end for seg selv og ligger i **web-ui** mappen og backend som en enkeltstående applikasjon som ligger i **api** mappen. 
+Backend har en BackgroundService (FiksResponseMessageService.cs) som konsumerer meldinger fra Fiks-IO og har dermed sin egen Fiks-IO klient. 
+Sending av meldinger tar FiksRequestMessageService.cs seg av og har også sin egen Fiks-IO klient. 
+Merk at denne todelingen gjør at FiksRequestMessageService ikke trenger å bry seg om tilstanden til connection mot Fiks-IO (health/keepAlive) da den bare bruker rest-api for å sende meldinger. 
+
+
 ## TestCase
 TestCasene ligger i mappen `KS.FiksProtokollValidator.WebAPI/TestCases`. Deretter under mappe for den protokollen TestCase tilhører. F.eks. mappen `no.ks.fiks.arkiv.v1` for Fiks-Arkiv protokollen.
 Et TestCase har sin egen mappe med et kortnavn for testen. Typisk er navnet bestående av den meldingstypen den tester + en suffix. 

--- a/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksIOClientConsumerService.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksIOClientConsumerService.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using KS.Fiks.IO.Client;
+using Serilog;
+
+namespace KS.FiksProtokollValidator.WebAPI.FiksIO;
+
+public class FiksIOClientConsumerService : IFiksIOClientConsumerService
+{
+    private static readonly ILogger Logger = Log.ForContext(MethodBase.GetCurrentMethod()?.DeclaringType);
+    public IFiksIOClient FiksIOConsumerClient { get; private set; }
+    private AppSettings _appSettings;
+
+    public FiksIOClientConsumerService(AppSettings appAppSettings)
+    {
+        _appSettings = appAppSettings;
+        Initialization = InitializeAsync();
+    }
+
+    public Task Initialization { get; private set; }
+
+    private async Task InitializeAsync()
+    {
+        FiksIOConsumerClient = await FiksIOClient.CreateAsync(FiksIOConfigurationBuilder.CreateFiksIOConfiguration(_appSettings));
+    }
+
+    public bool IsHealthy()
+    {
+        if (FiksIOConsumerClient != null)
+        {
+            var status = FiksIOConsumerClient.IsOpen();
+            Logger.Debug($"FiksIOClientConsumerService: FiksIOCClient.IsOpen() returns {status}");
+            return status;
+        }
+        Logger.Error("FiksIOClientConsumerService: FiksIOClient is null. Returning not healthy.");
+        return false;
+    }
+
+    public async Task Reconnect()
+    {
+        FiksIOConsumerClient.Dispose();
+        Initialization = InitializeAsync();
+    }
+}

--- a/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksIOConfigurationBuilder.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksIOConfigurationBuilder.cs
@@ -56,7 +56,7 @@ namespace KS.FiksProtokollValidator.WebAPI.FiksIO
                 port: appSettings.FiksIOConfig.AmqpPort, 
                 sslOption1,
                 "Fiks Protokollvalidator",
-                keepAlive: true);
+                keepAlive: false);
 
             // Combine all configurations
             return new FiksIOConfiguration(

--- a/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksResponseMessageService.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksResponseMessageService.cs
@@ -141,5 +141,10 @@ namespace KS.FiksProtokollValidator.WebAPI.FiksIO
                 mottattMeldingArgs.SvarSender?.Ack();
             }
         }
+        
+        public bool isHealthy()
+        {
+            return _client.IsOpen();
+        }
     }
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/FiksIO/IFiksIOClientConsumerService.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/FiksIO/IFiksIOClientConsumerService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using KS.Fiks.IO.Client;
+
+namespace KS.FiksProtokollValidator.WebAPI.FiksIO;
+
+public interface IFiksIOClientConsumerService : IAsyncInitialization
+{
+    public bool IsHealthy();
+    public Task Reconnect();
+    IFiksIOClient FiksIOConsumerClient { get; }
+}

--- a/api/KS.FiksProtokollValidator.WebAPI/Health/FiksIOHealthCheck.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Health/FiksIOHealthCheck.cs
@@ -7,26 +7,23 @@ namespace KS.FiksProtokollValidator.WebAPI.Health;
 
 public class FiksIOHealthCheck : IHealthCheck
 {
-    private readonly FiksResponseMessageService _fiksResponseMessageService;
+    private readonly IFiksIOClientConsumerService _fiksIoClientService;
     
-    public FiksIOHealthCheck(FiksResponseMessageService fiksResponseMessageService)
+    public FiksIOHealthCheck(IFiksIOClientConsumerService fiksIoClientService)
     {
-        _fiksResponseMessageService = fiksResponseMessageService;
+        _fiksIoClientService = fiksIoClientService;
     }
     
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
     {
-        var isHealthy = _fiksResponseMessageService.isHealthy();
-        
-        if (isHealthy)
+        if (!_fiksIoClientService.IsHealthy())
         {
             return Task.FromResult(
-                HealthCheckResult.Healthy("Validator API health er ok."));
+                new HealthCheckResult(
+                    context.Registration.FailureStatus, "Validator API health er ikke ok. FiksIOClient for consumer er ikke healthy."));
         }
 
         return Task.FromResult(
-            new HealthCheckResult(
-                context.Registration.FailureStatus, "Validator API health er ikke ok."));
-
+            HealthCheckResult.Healthy("Validator API health er ok."));
     }
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/Health/FiksIOHealthCheck.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Health/FiksIOHealthCheck.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using KS.FiksProtokollValidator.WebAPI.FiksIO;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace KS.FiksProtokollValidator.WebAPI.Health;
+
+public class FiksIOHealthCheck : IHealthCheck
+{
+    private readonly FiksResponseMessageService _fiksResponseMessageService;
+    
+    public FiksIOHealthCheck(FiksResponseMessageService fiksResponseMessageService)
+    {
+        _fiksResponseMessageService = fiksResponseMessageService;
+    }
+    
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+    {
+        var isHealthy = _fiksResponseMessageService.isHealthy();
+        
+        if (isHealthy)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Healthy("Validator API health er ok."));
+        }
+
+        return Task.FromResult(
+            new HealthCheckResult(
+                context.Registration.FailureStatus, "Validator API health er ikke ok."));
+
+    }
+}

--- a/api/KS.FiksProtokollValidator.WebAPI/Startup.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Startup.cs
@@ -14,8 +14,8 @@ namespace KS.FiksProtokollValidator.WebAPI
 {
     public class Startup
     {
-        private readonly string AllowedOrigins = "_allowedOrigins";
-        
+        private const string AllowedOrigins = "_allowedOrigins";
+
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;


### PR DESCRIPTION
La til healthz og self-healing i BackgroundService

Viser hvordan man kan bruke Fiks-IO-client IsOpen() både for å eksponere helsen til connection og evt lage en egen self-healing mekanisme.