### PR TITLE
Korrigert tekst i testcasene for søk

### DIFF
--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN1/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN1/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på respons='mappe' og felt='mappe.tittel' med responsType='minimum'",
-    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappe.tittel', respons='mappe', responsType='minimum'",
+    "testName": "Søk på mappe (mappeSokdefinisjon) og felt='mappeTittel' med responsType='minimum'",
+    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappeTittel', sokdefinisjon er mappeSokdefinisjon, responsType='minimum'",
     "testStep": "Normalsituasjon 1",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN2/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN2/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på respons='mappe' og felt='mappe.tittel' med responsType='utvidet'",
-    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappe.tittel', respons='mappe', responsType='utvidet'",
+    "testName": "Søk på mappe (mappeSokdefinisjon) og felt='mappeTittel' med responsType='utvidet'",
+    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappeTittel', sokdefinisjon er mappeSokdefinisjon, responsType='utvidet'",
     "testStep": "Normalsituasjon 2",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN3/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN3/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på respons='mappe' og felt='mappe.tittel' med responsType='noekler'",
-    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappe.tittel', respons='mappe', responsType='noekler'",
+    "testName": "Søk på mappe (mappeSokdefinisjon) og felt='mappeTittel' med responsType='noekler'",
+    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappeTittel', sokdefinisjon er mappeSokdefinisjon, responsType='noekler'",
     "testStep": "Normalsituasjon 3",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN4/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN4/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på 'sak.saksdato' mellom 2 datoer med responsType 'minimum'",
-    "description": "Søker på saksmapper som har saksdato mellom 2 datoer. felt='sak.saksdato', respons='saksmappe', responsType='minimum'",
+    "testName": "Søk på saksmappe (saksmappeSokdefinisjon) og felt='sakSaksdato' mellom 2 datoer med responsType 'minimum'",
+    "description": "Søker på saksmapper som har saksdato mellom 2 datoer. felt='sakSaksdato', sokdefinisjon er saksmappeSokdefinisjon, responsType='minimum'",
     "testStep": "Normalsituasjon 4",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN5/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN5/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på respons='saksmappe' og felt='mappe.tittel' med responsType='minimum'",
-    "description": "Søker på alle saksmapper som inneholder 'test' i tittelen. felt='mappe.tittel', respons='saksmappe', responsType='minimum'",
+    "testName": "Søk på saksmappe (saksmappeSokdefinisjon) og felt='mappeTittel' med responsType='minimum'",
+    "description": "Søker på alle saksmapper som inneholder 'test' i tittelen. felt='mappeTittel', sokdefinisjon er saksmappeSokdefinisjon, responsType='minimum'",
     "testStep": "Normalsituasjon 5",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN6/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN6/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på respons='saksmappe' og felt='mappe.tittel' med responsType='utvidet'",
-    "description": "Søker på alle saksmapper som inneholder 'test' i tittelen. felt='mappe.tittel', respons='saksmappe', responsType='utvidet'",
+    "testName": "Søk på saksmappe (saksmappeSokdefinisjon) og felt='mappeTittel' med responsType='utvidet'",
+    "description": "Søker på alle saksmapper som inneholder 'test' i tittelen. felt='mappeTittel', sokdefinisjon er saksmappeSokdefinisjon, responsType='utvidet'",
     "testStep": "Normalsituasjon 6",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN7/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN7/testInformation.json
@@ -1,6 +1,6 @@
 ﻿{
-    "testName": "Søk på respons='saksmappe' og felt='mappe.tittel' med responsType='noekler'",
-    "description": "Søker på alle mapper som inneholder 'test' i tittelen. felt='mappe.tittel', respons='saksmappe', responsType='noekler'",
+    "testName": "Søk på saksmappe (saksmappeSokdefinisjon) og felt='mappeTittel' med responsType='noekler'",
+    "description": "Søker på alle saksmapper som inneholder 'test' i tittelen. felt='mappeTittel', sokdefinisjon er saksmappeSokdefinisjon, responsType='noekler'",
     "testStep": "Normalsituasjon 7",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.sok",
     "operation": "NySok",


### PR DESCRIPTION
Korrigert tekst i testcasene for søk

I testInformation for alle søk testcases var `testName` og `description` ikke korrigert i henhold til siste versjon av `sok.xsd`