### PR TITLE
Endret til operator = wildcarquery for søk med wildcard

### DIFF
--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN1/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN1/sok.xml
@@ -8,7 +8,7 @@
 	<sokdefinisjon xsi:type="mappeSokdefinisjon">
 		<responstype>minimum</responstype>
 		<parametere>
-			<operator>equal</operator>
+			<operator>wildcardquery</operator>
 			<sokVerdier>
 				<stringvalues>
 					<value>Test*</value>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN2/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN2/sok.xml
@@ -8,7 +8,7 @@
 	<sokdefinisjon xsi:type="mappeSokdefinisjon">
 		<responstype>utvidet</responstype>
 		<parametere>
-			<operator>equal</operator>
+			<operator>wildcardquery</operator>
 			<sokVerdier>
 				<stringvalues>
 					<value>Test*</value>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN3/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN3/sok.xml
@@ -8,7 +8,7 @@
 	<sokdefinisjon xsi:type="mappeSokdefinisjon">
 		<responstype>noekler</responstype>
 		<parametere>
-			<operator>equal</operator>
+			<operator>wildcardquery</operator>
 			<sokVerdier>
 				<stringvalues>
 					<value>Test*</value>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN5/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN5/sok.xml
@@ -8,7 +8,7 @@
 	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
 		<responstype>minimum</responstype>
 		<parametere>
-			<operator>equal</operator>
+			<operator>wildcardquery</operator>
 			<sokVerdier>
 				<stringvalues>
 					<value>Test*</value>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN6/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN6/sok.xml
@@ -8,7 +8,7 @@
 	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
 		<responstype>utvidet</responstype>
 		<parametere>
-			<operator>equal</operator>
+			<operator>wildcardquery</operator>
 			<sokVerdier>
 				<stringvalues>
 					<value>Test*</value>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN7/sok.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/NySokN7/sok.xml
@@ -8,7 +8,7 @@
 	<sokdefinisjon xsi:type="saksmappeSokdefinisjon">
 		<responstype>noekler</responstype>
 		<parametere>
-			<operator>equal</operator>
+			<operator>wildcardquery</operator>
 			<sokVerdier>
 				<stringvalues>
 					<value>Test*</value>


### PR DESCRIPTION
Endret til operator = wildcarquery for søk med wildcard

I siste versjon av Fiks-Arkiv spesifikasjonen er det nå gått over til at operatoren for søk skal være `wildcardquery` når man søker vha wildcard *.