### PR TITLE
Sjekker at mottatt melding er asice signed

### DIFF
--- a/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
+++ b/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.9" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.13" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Serilog" Version="2.12.0" />
   </ItemGroup>

--- a/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
+++ b/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.8" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.9" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.11" />

--- a/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
+++ b/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.8" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.9" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />

--- a/api/KS.FiksProtokollValidator.WebAPI/Data/FiksIOMessageDBContext.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Data/FiksIOMessageDBContext.cs
@@ -1,5 +1,6 @@
 using KS.FiksProtokollValidator.WebAPI.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 
 namespace KS.FiksProtokollValidator.WebAPI.Data
 {
@@ -20,6 +21,17 @@ namespace KS.FiksProtokollValidator.WebAPI.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<TestCase>().HasIndex(t => t.TestId).IsUnique();
+        }
+    }
+    
+    public class FiksIOMessageDBContextFactory : IDesignTimeDbContextFactory<FiksIOMessageDBContext>
+    {
+        public FiksIOMessageDBContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<FiksIOMessageDBContext>();
+            optionsBuilder.UseSqlServer("your connection string");
+
+            return new FiksIOMessageDBContext(optionsBuilder.Options);
         }
     }
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/Data/FiksIOMessageDBContext.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Data/FiksIOMessageDBContext.cs
@@ -1,6 +1,5 @@
 using KS.FiksProtokollValidator.WebAPI.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
 
 namespace KS.FiksProtokollValidator.WebAPI.Data
 {
@@ -21,17 +20,6 @@ namespace KS.FiksProtokollValidator.WebAPI.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<TestCase>().HasIndex(t => t.TestId).IsUnique();
-        }
-    }
-    
-    public class FiksIOMessageDBContextFactory : IDesignTimeDbContextFactory<FiksIOMessageDBContext>
-    {
-        public FiksIOMessageDBContext CreateDbContext(string[] args)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<FiksIOMessageDBContext>();
-            optionsBuilder.UseSqlServer("your connection string");
-
-            return new FiksIOMessageDBContext(optionsBuilder.Options);
         }
     }
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/Data/Migrations/20230116074819_AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse.Designer.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Data/Migrations/20230116074819_AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse.Designer.cs
@@ -4,6 +4,7 @@ using KS.FiksProtokollValidator.WebAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KS.FiksProtokollValidator.WebAPI.Data.Migrations
 {
     [DbContext(typeof(FiksIOMessageDBContext))]
-    partial class FiksIOMessageDBContextModelSnapshot : ModelSnapshot
+    [Migration("20230116074819_AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse")]
+    partial class AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/KS.FiksProtokollValidator.WebAPI/Data/Migrations/20230116074819_AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Data/Migrations/20230116074819_AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KS.FiksProtokollValidator.WebAPI.Data.Migrations
+{
+    public partial class AddIsAsiceVerifiedAndPayloadMessagesToFiksResponse : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "IsAsiceSigned",
+                table: "FiksResponse",
+                newName: "IsAsiceVerified");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PayloadErrors",
+                table: "FiksResponse",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PayloadErrors",
+                table: "FiksResponse");
+
+            migrationBuilder.RenameColumn(
+                name: "IsAsiceVerified",
+                table: "FiksResponse",
+                newName: "IsAsiceSigned");
+        }
+    }
+}

--- a/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksResponseMessageService.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/FiksIO/FiksResponseMessageService.cs
@@ -71,9 +71,9 @@ namespace KS.FiksProtokollValidator.WebAPI.FiksIO
             {
                 try
                 {
-                    await using var verifyStream2 = mottattMeldingArgs.Melding.DecryptedStream.Result;
+                    using var verifyStream2 = mottattMeldingArgs.Melding.DecryptedStream;
                     IAsicReader asiceReader = new AsiceReader();
-                    using var asiceReadModel = asiceReader.Read(verifyStream2);
+                    using var asiceReadModel = asiceReader.Read(await verifyStream2);
                   
                     // Verify asice and read payload
                     foreach (var asiceVerifyReadEntry in asiceReadModel.Entries)

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.8" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.9" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5" />
     <PackageReference Include="KS.Fiks.IO.Client" Version="3.0.1" />
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.18" />

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -39,21 +39,21 @@
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.18" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
     <PackageReference Include="KS.Fiks.Protokoller.V1" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.13">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.11" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/api/KS.FiksProtokollValidator.WebAPI/Models/FiksResponse.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Models/FiksResponse.cs
@@ -15,6 +15,12 @@ namespace KS.FiksProtokollValidator.WebAPI.Models
 
         [Required]
         public string Type { get; set; }
+        
+        [Required]
+        public bool IsAsiceVerified { get; set; }
+        
+        [Required]
+        public string PayloadErrors { get; set; }
 
         public List<FiksPayload> FiksPayloads { get; set; }
     }

--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/Resources/ValidationErrorMessages.Designer.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/Resources/ValidationErrorMessages.Designer.cs
@@ -164,5 +164,17 @@ namespace KS.FiksProtokollValidator.WebAPI.Validation.Resources {
                 return ResourceManager.GetString("SokeresultatIsNull", resourceCulture);
             }
         }
+        
+        public static string MissingAsiceSigning {
+            get {
+                return ResourceManager.GetString("MissingAsiceSigning", resourceCulture);
+            }
+        }
+        
+        public static string PayloadError {
+            get {
+                return ResourceManager.GetString("PayloadError", resourceCulture);
+            }
+        }
     }
 }

--- a/api/KS.FiksProtokollValidator.WebAPI/Validation/Resources/ValidationErrorMessages.resx
+++ b/api/KS.FiksProtokollValidator.WebAPI/Validation/Resources/ValidationErrorMessages.resx
@@ -177,4 +177,10 @@
   <data name="SokeresultatIsNull" xml:space="preserve">
     <value>Søkeresultat var null</value>
   </data>
+  <data name="MissingAsiceSigning" xml:space="preserve">
+    <value>Mangler asice signering.</value>
+  </data>
+  <data name="PayloadError" xml:space="preserve">
+    <value>Noe var galt med payload. Feilmelding: {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Sjekker at mottatt melding er asice signed

Skal vise det som en feil på test-rapport siden i validatoren hvis mottatt melding ikke er asice signert. Utvidet også mottakskomponent til å lagre feilmeldinger hvis det dukker opp andre feil i lesing av payload. Slik at dette også kan visess på test-rapport siden.
