### PR TITLE
Endret testcase for hentJournalpostN2

### DIFF
--- a/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
+++ b/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.13" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.14" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />

--- a/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
+++ b/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.13" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.14" />
     <PackageReference Include="KS.Fiks.Plan.Models.V2" Version="0.0.1-build.20230310103127590" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="nunit" Version="3.13.3" />

--- a/api/KS.FiksProtokollValidator.Tests/ValidatorTest.cs
+++ b/api/KS.FiksProtokollValidator.Tests/ValidatorTest.cs
@@ -125,7 +125,7 @@ namespace KS.FiksProtokollValidator.Tests
         }
 
         [Test]
-        public void ExistingAttributeIsFound()
+        public void ExistingAttributeIsFoundAndAsiceIsMissing()
         {
             _fiksResponseTest.ExpectedValue = "journalpostKvittering";
             _fiksResponseTest.ValueType = SearchValueType.Attribute;
@@ -146,10 +146,16 @@ namespace KS.FiksProtokollValidator.Tests
             var expectedMessage = string.Format(
                 ValidationErrorMessages.MissingAttributeOnPayloadElement,
                 customTest.ExpectedValue, xmlNodeToLookAt);
+            
+            var expectedMessage2 = string.Format(
+                ValidationErrorMessages.MissingAsiceSigning,
+                customTest.ExpectedValue, xmlNodeToLookAt);
 
             Assert.Contains(expectedMessage, _fiksRequest.FiksResponseValidationErrors);
+            Assert.Contains(expectedMessage2, _fiksRequest.FiksResponseValidationErrors);
 
             _fiksRequest.FiksResponseValidationErrors.Remove(expectedMessage);
+            _fiksRequest.FiksResponseValidationErrors.Remove(expectedMessage2);
 
             Assert.IsEmpty(_fiksRequest.FiksResponseValidationErrors);
         }

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.13" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.9.14" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.5" />
     <PackageReference Include="KS.Fiks.IO.Client" Version="3.0.2" />
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.18" />

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostN2/arkivmelding.xml
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostN2/arkivmelding.xml
@@ -6,4 +6,6 @@
 			<noekkel>86af5c8f-e06e-4c5c-b49b-97ccb1ce68a2</noekkel>
 		</referanseEksternNoekkel>
 	</referanseTilRegistrering>
+	<inkluder>merknad</inkluder>
+	<inkluder>noekkelord</inkluder>
 </registreringHent>

--- a/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostN2/testInformation.json
+++ b/api/KS.FiksProtokollValidator.WebAPI/TestCases/no.ks.fiks.arkiv.v1/HentJournalpostN2/testInformation.json
@@ -1,6 +1,6 @@
 {
     "testName": "Hent Registrering - Normalsituasjon 2 - ReferanseEksternNoekkel som nøkkel",
-    "description": "Henter en journalpost basert på ReferanseEksternNoekkel som nøkkel",
+    "description": "Henter en journalpost basert på ReferanseEksternNoekkel som nøkkel og med inkluder typene noekkelord og merknad",
     "testStep": "Normalsituasjon 2 Input Journalpost med retur av Journalpost",
     "messageType": "no.ks.fiks.arkiv.v1.innsyn.registrering.hent",
     "operation": "HentJournalpost",


### PR DESCRIPTION
Testcase bruker nå `inkluder` også og har 2 inkluder-verdier.