### PR TITLE
Legg til direktelenke med ferdig utfylt fikskonto og fiksprotokoll

### DIFF
--- a/web-ui/src/components/NewTestSession.vue
+++ b/web-ui/src/components/NewTestSession.vue
@@ -20,6 +20,13 @@
     </div>
       <b-form-select v-model="selectedProtocol" v-on:change="getTestsByProtocol" :options="options" style="width:30%"></b-form-select>
     </div>
+    <b-link
+      :to="{
+        name: newTestSession,
+        query: { fikskonto: recipientId, fiksprotocol: selectedProtocol },
+      }"
+      >Direkte lenke</b-link
+    >
   
     <div style="margin: 40px 0">
       <b-form-group v-if="!hasRun">
@@ -116,6 +123,17 @@ export default {
   },
   
   data() {
+    const protocolOptions = [
+      { value: "ingen", text: 'Velg en FIKS-protokoll'},
+      { value: 'no.ks.fiks.arkiv.v1', text: 'no.ks.fiks.arkiv.v1' },
+      { value: 'no.ks.fiks.plan.v2', text: 'no.ks.fiks.plan.v2'},
+      { value: 'no.ks.fiks.matrikkelfoering.v2', text: 'no.ks.fiks.matrikkelfoering.v2'}
+    ]
+    const qproto = this.$route.query.fiksprotocol || protocolOptions[0].value;
+    const selectedProtocol = (
+      (qproto && protocolOptions.find((p) => p.value === qproto)) ||
+      protocolOptions[0]
+    ).value;
     return {
       title: "Ny Testsesjon",
       testCases: [],
@@ -133,13 +151,8 @@ export default {
       requestErrorStatusCode: 0,
       requestErrorMessage: "",
       tmpTests: [],
-      selectedProtocol: "ingen",
-        options: [
-          { value: "ingen", text: 'Velg en FIKS-protokoll'},
-          { value: 'no.ks.fiks.arkiv.v1', text: 'no.ks.fiks.arkiv.v1' },
-          { value: 'no.ks.fiks.plan.v2', text: 'no.ks.fiks.plan.v2'},
-          { value: 'no.ks.fiks.matrikkelfoering.v2', text: 'no.ks.fiks.matrikkelfoering.v2'}
-        ]
+      selectedProtocol,
+        options: protocolOptions 
     };
   },
   
@@ -147,6 +160,9 @@ export default {
     this.recipientId = this.$route.query.fikskonto;
     if(this.$route.query.fikskonto) {
       this.fiksAccountPresent = true;
+      if (this.selectedProtocol && this.selectedProtocol !== 'ingen') {
+        this.getTestsByProtocol();
+      }
     }
   },
   


### PR DESCRIPTION
Dette legger til muligheten for å få fiks-protokollen inn fra url-søkeparametre, slik som allerede var mulig for fiks-konto.

Det legger også en lenke til den siden, slik at det blir lettere for utviklere/testere å oppdage funksjonaliteten.

![image](https://github.com/ks-no/fiks-protokoll-validator/assets/5629981/6a2c5be5-c3c8-45a3-85a6-f787533e60c5)


Eksempel lenke: http://localhost:8080/fiks-validator/NewTestSession?fikskonto=7d3b261f-d756-4d89-950a-a5612c873194&fiksprotocol=no.ks.fiks.arkiv.v1