### PR TITLE
Dependency bumps

### DIFF
--- a/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
+++ b/api/KS.FiksProtokollValidator.TestSessionCleanUp/KS.FiksProtokollValidator.TestSessionCleanUp.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="1.0.4" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageReference Include="Serilog" Version="4.2.0" />
   </ItemGroup>
 

--- a/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
+++ b/api/KS.FiksProtokollValidator.Tests/KS.FiksProtokollValidator.Tests.csproj
@@ -56,11 +56,11 @@
   <ItemGroup>
     <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="1.0.4" />
     <PackageReference Include="KS.Fiks.Matrikkelfoering.Models.V2" Version="1.0.0" />
-    <PackageReference Include="KS.Fiks.Plan.Models.V2" Version="0.9.11" />
+    <PackageReference Include="KS.Fiks.Plan.Models.V2" Version="1.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="nunit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
+++ b/api/KS.FiksProtokollValidator.WebAPI/KS.FiksProtokollValidator.WebAPI.csproj
@@ -46,10 +46,10 @@
     <PackageReference Include="KS.Fiks.IO.Politisk.Behandling.Client" Version="0.0.18" />
     <PackageReference Include="KS.Fiks.Matrikkelfoering.Models.V2" Version="1.0.0" />
     <PackageReference Include="KS.Fiks.Plan.Client" Version="0.0.13" />
-    <PackageReference Include="KS.Fiks.Plan.Models.V2" Version="0.9.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="KS.Fiks.Plan.Models.V2" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ks-no/openshift-nginx/fiks-nginx-openshift:1.8.4 as production-stage
+FROM ghcr.io/ks-no/openshift-nginx/fiks-nginx-openshift:1.9.0 as production-stage
 
 COPY dist /usr/share/nginx/html
 

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -37,9 +37,9 @@
     "@vue/eslint-config-prettier": "^10.2.0",
     "babel-eslint": "^10.1.0",
     "dotenv": "^16.4.7",
-    "eslint": "^9.19.0",
+    "eslint": "^9.21.0",
     "eslint-plugin-prettier": "^5.2.3",
     "eslint-plugin-vue": "^9.32.0",
-    "prettier": "^3.4.2"
+    "prettier": "^3.5.2"
   }
 }


### PR DESCRIPTION
**Bumps:** 

API:
- Bumps [KS.Fiks.Plan.Models.V2](https://github.com/ks-no/fiks-plan-models-dotnet) from 0.9.11 to 1.0.0.
- Bumps [NUnit3TestAdapter](https://github.com/nunit/nunit3-vs-adapter) from 4.6.0 to 5.0.0.
- Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.12.0 to 17.13.0.
- Bumps [Microsoft.AspNetCore.SignalR.Client](https://github.com/dotnet/aspnetcore) from 9.0.1 to 9.0.2.
- Bumps [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://github.com/dotnet/aspnetcore) from 8.0.12 to 8.0.13.
- Bumps [Microsoft.EntityFrameworkCore](https://github.com/dotnet/efcore) from 9.0.1 to 9.0.2.
- Bumps [Microsoft.Extensions.Hosting](https://github.com/dotnet/runtime) from 9.0.1 to 9.0.2.

WEB:
- Bumps [eslint](https://github.com/eslint/eslint) from 9.19.0 to 9.21.0.
- Bumps [prettier](https://github.com/prettier/prettier) from 3.4.2 to 3.5.2.

DOCKER:
- Bumps ks-no/openshift-nginx/fiks-nginx-openshift from 1.8.4 to 1.9.0.
