### PR TITLE
Skriv JSON-schemas til /tmp i stedet for /app/Schemas

### DIFF
--- a/api/KS.FiksProtokollValidator.WebAPI/TjenerValidator/Validation/JsonValidator.cs
+++ b/api/KS.FiksProtokollValidator.WebAPI/TjenerValidator/Validation/JsonValidator.cs
@@ -13,8 +13,9 @@ namespace KS.FiksProtokollValidator.WebAPI.TjenerValidator.Validation
 {
     public class JsonValidator : IDisposable
     {
-        private const string SaksfaserAssemblyBaseFilename = "KS.Fiks.Saksfaser.Models.V1.Schema.V1"; 
-        private const string FiksPlanAssemblyBaseFilename = "KS.Fiks.Plan.Models.V2.Schema.V2"; 
+        private const string SaksfaserAssemblyBaseFilename = "KS.Fiks.Saksfaser.Models.V1.Schema.V1";
+        private const string FiksPlanAssemblyBaseFilename = "KS.Fiks.Plan.Models.V2.Schema.V2";
+        private static readonly string SchemasDirectory = Path.Combine(Path.GetTempPath(), "fiks-protokoll-validator-schemas");
         private string assemblyName;
         private string assemblyBaseFilename;
 
@@ -22,7 +23,7 @@ namespace KS.FiksProtokollValidator.WebAPI.TjenerValidator.Validation
         {
             try
             {
-                Directory.CreateDirectory("Schemas");
+                Directory.CreateDirectory(SchemasDirectory);
             }
             catch(Exception e)
             {
@@ -75,7 +76,7 @@ namespace KS.FiksProtokollValidator.WebAPI.TjenerValidator.Validation
         private void writeSchemaToDisk(string messageType)
         {
             var content = GetSchemaFromAssembly(messageType);
-            File.WriteAllText($"./Schemas/{messageType}.schema.json", content);
+            File.WriteAllText(Path.Combine(SchemasDirectory, $"{messageType}.schema.json"), content);
         }
 
         private string GetSchemaFromAssembly(string messagename)
@@ -118,13 +119,11 @@ namespace KS.FiksProtokollValidator.WebAPI.TjenerValidator.Validation
 
             using var reader = new JsonTextReader(schemaStreamReader);
             var resolver = new JSchemaUrlResolver();
-            //var baseUri = Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.FullName;
-            var baseUri = Directory.GetCurrentDirectory();
 
             var schema = JSchema.Load(reader, new JSchemaReaderSettings()
                 {
                     Resolver = resolver,
-                    BaseUri = new Uri($"{baseUri}/Schemas/{messageType}.schema.json") // Hoved schema
+                    BaseUri = new Uri(Path.Combine(SchemasDirectory, $"{messageType}.schema.json")) // Hoved schema
                 }
             );
             schema.ExtensionData.Remove("definitions");


### PR DESCRIPTION
## Problem

API-containeren krasjer i testmiljøet med følgende feil ved oppstart:

```
System.UnauthorizedAccessException: Access to the path '/app/Schemas/no.ks.fiks.saksfaser.v1.felles.dokument.schema.json' is denied.
---> System.IO.IOException: Permission denied
```

`JsonValidator` ekstraherer JSON-schemas fra innebygde NuGet-ressurser og skriver dem til disk ved oppstart. Tidligere ble de skrevet til `./Schemas/` relativt til applikasjonens arbeidskatalog — dvs. `/app/Schemas/` inne i containeren.

`Init()`-metoden forsøker å opprette denne katalogen, men svelger eventuelle exceptions stille. Hvis katalogopprettelsen feiler, fortsetter koden og forsøker å skrive filer — noe som da kaster `UnauthorizedAccessException`.

## Rotårsak

CI/CD ble migrert fra Jenkinsfile til GitHub Actions i versjon 2.0.5 (`59c6570`). Den nye deployment-pipelinen via `ks-helm` ser ut til å anvende strengere Kubernetes security contexts (f.eks. `runAsNonRoot: true` eller en ikke-root UID), som gjør at containeren ikke har skrivetilgang til `/app/`.

Versjon 2.0.4, som ble deployet via Jenkins, hadde ikke dette problemet.

## Løsning

Endrer schemas-katalogen fra `/app/Schemas` til `Path.GetTempPath()` → `/tmp/fiks-protokoll-validator-schemas`.

`/tmp` har alltid skrivetilgang for alle brukere, uavhengig av hvilken UID containeren kjører som.

`JSchemaUrlResolver` løser `$ref`-referanser relativt til `BaseUri` — siden alle schemas skrives til samme katalog, fungerer referansene korrekt som før.